### PR TITLE
Add Claude Code learning support with guides and activity tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,41 @@
     <title>AskTerminal</title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <!-- Loading indicator - replaced when Vue mounts -->
+      <div style="
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+        background: #f3f4f6;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      ">
+        <div style="
+          background: white;
+          padding: 32px 48px;
+          border-radius: 12px;
+          box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+          text-align: center;
+        ">
+          <div style="
+            width: 40px;
+            height: 40px;
+            border: 3px solid #e5e7eb;
+            border-top-color: #6366f1;
+            border-radius: 50%;
+            margin: 0 auto 16px;
+            animation: spin 0.8s linear infinite;
+          "></div>
+          <div style="color: #374151; font-size: 14px;">Loading Ask Terminal...</div>
+        </div>
+      </div>
+      <style>
+        @keyframes spin {
+          to { transform: rotate(360deg); }
+        }
+      </style>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/components/ActivityHistoryView.vue
+++ b/src/components/ActivityHistoryView.vue
@@ -1,0 +1,668 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useClaudeStore, type ClaudeActivity, type TodoItem, type ConversationRound } from '../stores/claude'
+
+const claudeStore = useClaudeStore()
+
+// Tool colors for visual distinction
+const toolColors: Record<string, string> = {
+  Read: 'tool-read',
+  Write: 'tool-write',
+  Edit: 'tool-edit',
+  Bash: 'tool-bash',
+  Glob: 'tool-glob',
+  Grep: 'tool-grep',
+  WebFetch: 'tool-web',
+  WebSearch: 'tool-web',
+  Task: 'tool-task',
+  TodoWrite: 'tool-task'
+}
+
+function getActivityLabel(activity: ClaudeActivity): string {
+  if (activity.type === 'thinking') return 'Thinking'
+  if (activity.type === 'tool_complete') return 'Done'
+  if (activity.type === 'response') return 'Response'
+  if (activity.type === 'error') return 'Error'
+  if (activity.tool) return activity.tool
+  return activity.type
+}
+
+function getActivityClass(activity: ClaudeActivity): string {
+  if (activity.type === 'thinking') return 'type-thinking'
+  if (activity.type === 'tool_complete') return 'type-complete'
+  if (activity.type === 'error') return 'type-error'
+  if (activity.tool) return toolColors[activity.tool] || ''
+  return ''
+}
+
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp)
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true
+  })
+}
+
+function formatShortTime(timestamp: number): string {
+  const date = new Date(timestamp)
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true
+  })
+}
+
+const sessionDuration = computed(() => {
+  if (!claudeStore.sessionStartTime) return null
+  const elapsed = Date.now() - claudeStore.sessionStartTime
+  const minutes = Math.floor(elapsed / 60000)
+  const seconds = Math.floor((elapsed % 60000) / 1000)
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+})
+
+// Count total activities in a round
+function getRoundActivityCount(round: ConversationRound): number {
+  let count = round.activities.length
+  round.todos.forEach(todo => {
+    count += todo.activities.length
+  })
+  return count
+}
+
+// Get todo status icon
+function getTodoStatusIcon(status: TodoItem['status']): string {
+  switch (status) {
+    case 'completed': return '✓'
+    case 'in_progress': return '●'
+    default: return '○'
+  }
+}
+
+function getTodoStatusClass(status: TodoItem['status']): string {
+  switch (status) {
+    case 'completed': return 'status-completed'
+    case 'in_progress': return 'status-in-progress'
+    default: return 'status-pending'
+  }
+}
+
+// Reverse rounds to show most recent first
+const rounds = computed(() => {
+  return [...(claudeStore.conversationRounds || [])].reverse()
+})
+
+// Check if we have hierarchical data or should fall back to flat list
+const hasRounds = computed(() => (claudeStore.conversationRounds?.length || 0) > 0)
+</script>
+
+<template>
+  <div class="activity-history">
+    <!-- Active Session -->
+    <template v-if="claudeStore.isClaudeSession">
+      <div class="session-header">
+        <div class="session-status active">
+          <span class="status-dot"></span>
+          <span>Claude session active</span>
+        </div>
+        <div class="header-actions">
+          <button
+            v-if="hasRounds"
+            @click="claudeStore.collapseAllRounds"
+            class="collapse-btn"
+            title="Collapse all"
+          >
+            Collapse
+          </button>
+          <span v-if="sessionDuration" class="session-duration">{{ sessionDuration }}</span>
+        </div>
+      </div>
+
+      <!-- Current Activity -->
+      <div v-if="claudeStore.currentActivity" class="current-activity">
+        <div class="current-label">Currently</div>
+        <div class="current-content">
+          <div v-if="claudeStore.isThinking" class="thinking-state">
+            <span class="spinner"></span>
+            <span>Thinking...</span>
+          </div>
+          <div v-else-if="claudeStore.currentTool" class="tool-state">
+            <span class="tool-badge" :class="toolColors[claudeStore.currentTool]">
+              {{ claudeStore.currentTool }}
+            </span>
+            <span v-if="claudeStore.currentActivity.description" class="tool-detail">
+              {{ claudeStore.currentActivity.description }}
+            </span>
+          </div>
+          <div v-else class="idle-state">
+            Waiting for response...
+          </div>
+        </div>
+      </div>
+
+      <!-- Hierarchical View (Rounds with Todos) -->
+      <div v-if="hasRounds" class="rounds-section">
+        <div class="section-header">
+          <span>Conversation History</span>
+        </div>
+
+        <div class="rounds-list">
+          <div
+            v-for="round in rounds"
+            :key="round.id"
+            class="round-item"
+          >
+            <!-- Round Header -->
+            <button
+              class="round-header"
+              @click="claudeStore.toggleRoundCollapsed(round.id)"
+            >
+              <span class="collapse-icon">{{ round.collapsed ? '▶' : '▼' }}</span>
+              <span class="round-prompt">{{ round.promptSummary }}</span>
+              <span class="round-meta">
+                <span class="round-time">{{ formatShortTime(round.timestamp) }}</span>
+                <span class="round-count">{{ getRoundActivityCount(round) }} activities</span>
+              </span>
+            </button>
+
+            <!-- Round Content (when expanded) -->
+            <div v-if="!round.collapsed" class="round-content">
+              <!-- Todos -->
+              <div
+                v-for="(todo, todoIndex) in round.todos"
+                :key="todoIndex"
+                class="todo-item"
+              >
+                <button
+                  class="todo-header"
+                  @click="claudeStore.toggleTodoCollapsed(round.id, todoIndex)"
+                >
+                  <span class="todo-status" :class="getTodoStatusClass(todo.status)">
+                    {{ getTodoStatusIcon(todo.status) }}
+                  </span>
+                  <span class="todo-content">{{ todo.content }}</span>
+                  <span v-if="todo.activities.length > 0" class="todo-count">
+                    {{ todo.activities.length }}
+                  </span>
+                  <span v-if="todo.activities.length > 0" class="collapse-icon small">
+                    {{ todo.collapsed ? '▶' : '▼' }}
+                  </span>
+                </button>
+
+                <!-- Todo Activities -->
+                <ul v-if="!todo.collapsed && todo.activities.length > 0" class="activity-list nested">
+                  <li
+                    v-for="(activity, i) in todo.activities"
+                    :key="i"
+                    class="activity-item"
+                  >
+                    <span class="activity-badge" :class="getActivityClass(activity)">
+                      {{ getActivityLabel(activity) }}
+                    </span>
+                    <span v-if="activity.description" class="activity-desc">
+                      {{ activity.description }}
+                    </span>
+                  </li>
+                </ul>
+              </div>
+
+              <!-- General Activities (not tied to todos) -->
+              <ul v-if="round.activities.length > 0" class="activity-list">
+                <li
+                  v-for="(activity, i) in round.activities"
+                  :key="i"
+                  class="activity-item"
+                >
+                  <span class="activity-badge" :class="getActivityClass(activity)">
+                    {{ getActivityLabel(activity) }}
+                  </span>
+                  <span v-if="activity.description" class="activity-desc">
+                    {{ activity.description }}
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Flat Activity List (fallback when no rounds detected) -->
+      <div v-else-if="claudeStore.activityHistory.length > 0" class="flat-section">
+        <div class="section-header">Recent activity</div>
+        <ul class="activity-list">
+          <li
+            v-for="(activity, i) in claudeStore.recentActivities"
+            :key="i"
+            class="activity-item"
+          >
+            <span class="activity-time">{{ formatTime(activity.timestamp) }}</span>
+            <span class="activity-badge" :class="getActivityClass(activity)">
+              {{ getActivityLabel(activity) }}
+            </span>
+            <span v-if="activity.description" class="activity-desc">
+              {{ activity.description }}
+            </span>
+          </li>
+        </ul>
+      </div>
+    </template>
+
+    <!-- No Active Session -->
+    <div v-else class="empty-state">
+      <div class="empty-icon">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <circle cx="12" cy="12" r="10"/>
+          <path d="M12 6v6l4 2"/>
+        </svg>
+      </div>
+      <h3>No active Claude session</h3>
+      <p>Run <code>claude</code> in the terminal to start a session. Activity will appear here.</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.activity-history {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.session-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #e5e7eb;
+  margin-bottom: 12px;
+  flex-shrink: 0;
+}
+
+.session-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #374151;
+}
+
+.session-status.active .status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.collapse-btn {
+  font-size: 11px;
+  color: #6b7280;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  padding: 3px 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.collapse-btn:hover {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.session-duration {
+  font-size: 12px;
+  color: #6b7280;
+  font-family: 'Menlo', 'Monaco', monospace;
+}
+
+/* Current Activity */
+.current-activity {
+  background: linear-gradient(135deg, #f5f3ff 0%, #ede9fe 100%);
+  border: 1px solid #ddd6fe;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 16px;
+  flex-shrink: 0;
+}
+
+.current-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #7c3aed;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.current-content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.thinking-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #ddd6fe;
+  border-top-color: #7c3aed;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.tool-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tool-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.tool-detail {
+  font-size: 12px;
+  color: #6b7280;
+  font-family: 'Menlo', 'Monaco', monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 250px;
+}
+
+.idle-state {
+  font-size: 13px;
+  color: #9ca3af;
+  font-style: italic;
+}
+
+/* Tool Colors */
+.tool-read { background: #dbeafe; color: #1d4ed8; }
+.tool-write { background: #dcfce7; color: #15803d; }
+.tool-edit { background: #fef3c7; color: #b45309; }
+.tool-bash { background: #fce7f3; color: #be185d; }
+.tool-glob, .tool-grep { background: #e0e7ff; color: #4338ca; }
+.tool-web { background: #cffafe; color: #0e7490; }
+.tool-task { background: #f3e8ff; color: #7e22ce; }
+
+/* Section Headers */
+.section-header {
+  font-size: 11px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+/* Rounds Section */
+.rounds-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.rounds-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.round-item {
+  margin-bottom: 8px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.round-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: #f9fafb;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s;
+}
+
+.round-header:hover {
+  background: #f3f4f6;
+}
+
+.collapse-icon {
+  font-size: 10px;
+  color: #9ca3af;
+  width: 12px;
+}
+
+.collapse-icon.small {
+  font-size: 8px;
+  width: 10px;
+}
+
+.round-prompt {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: #374151;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.round-meta {
+  display: flex;
+  gap: 8px;
+  font-size: 11px;
+  color: #9ca3af;
+}
+
+.round-time {
+  font-family: 'Menlo', 'Monaco', monospace;
+}
+
+.round-content {
+  padding: 8px 12px 12px;
+  background: white;
+}
+
+/* Todo Items */
+.todo-item {
+  margin-bottom: 6px;
+}
+
+.todo-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: #fafafa;
+  border: 1px solid #f3f4f6;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  font-size: 12px;
+  transition: background 0.15s;
+}
+
+.todo-header:hover {
+  background: #f3f4f6;
+}
+
+.todo-status {
+  font-size: 12px;
+  width: 14px;
+  text-align: center;
+}
+
+.todo-status.status-completed { color: #22c55e; }
+.todo-status.status-in-progress { color: #f59e0b; }
+.todo-status.status-pending { color: #d1d5db; }
+
+.todo-content {
+  flex: 1;
+  color: #4b5563;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.todo-count {
+  font-size: 10px;
+  color: #9ca3af;
+  background: #f3f4f6;
+  padding: 1px 5px;
+  border-radius: 8px;
+}
+
+/* Activity Lists */
+.activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.activity-list.nested {
+  margin-left: 22px;
+  margin-top: 4px;
+  padding-left: 8px;
+  border-left: 2px solid #f3f4f6;
+}
+
+.activity-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 12px;
+}
+
+.activity-time {
+  font-size: 10px;
+  color: #9ca3af;
+  font-family: 'Menlo', 'Monaco', monospace;
+  flex-shrink: 0;
+}
+
+.activity-badge {
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 500;
+  background: #f3f4f6;
+  color: #6b7280;
+  flex-shrink: 0;
+}
+
+.activity-badge.type-thinking { background: #ede9fe; color: #7c3aed; }
+.activity-badge.type-complete { background: #dcfce7; color: #15803d; }
+.activity-badge.type-error { background: #fee2e2; color: #dc2626; }
+
+.activity-desc {
+  color: #6b7280;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Flat Section (fallback) */
+.flat-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.flat-section .activity-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.flat-section .activity-item {
+  padding: 6px 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.flat-section .activity-item:last-child {
+  border-bottom: none;
+}
+
+/* Empty State */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 40px 20px;
+  color: #6b7280;
+}
+
+.empty-icon {
+  color: #d1d5db;
+  margin-bottom: 16px;
+}
+
+.empty-state h3 {
+  font-size: 15px;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 8px 0;
+}
+
+.empty-state p {
+  font-size: 13px;
+  color: #6b7280;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.empty-state code {
+  background: #f3f4f6;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: 'Menlo', 'Monaco', monospace;
+  font-size: 12px;
+  color: #374151;
+}
+</style>

--- a/src/components/ClaudeActivityPanel.vue
+++ b/src/components/ClaudeActivityPanel.vue
@@ -1,0 +1,259 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useClaudeStore } from '../stores/claude'
+import { useUIStore } from '../stores/ui'
+import { useSettingsStore } from '../stores/settings'
+
+const claudeStore = useClaudeStore()
+const uiStore = useUIStore()
+const settingsStore = useSettingsStore()
+
+// Tool explanations for beginners
+const toolDescriptions: Record<string, string> = {
+  Read: 'Reading a file to understand its contents',
+  Write: 'Creating or replacing a file with new content',
+  Edit: 'Making targeted changes to an existing file',
+  Bash: 'Running a terminal command',
+  Glob: 'Finding files by pattern (like *.ts)',
+  Grep: 'Searching file contents for text',
+  WebFetch: 'Retrieving content from a URL',
+  WebSearch: 'Searching the web for information',
+  Task: 'Running a subtask with a specialized agent',
+  TodoWrite: 'Tracking task progress'
+}
+
+// Tool colors for visual distinction
+const toolColors: Record<string, string> = {
+  Read: 'tool-read',
+  Write: 'tool-write',
+  Edit: 'tool-edit',
+  Bash: 'tool-bash',
+  Glob: 'tool-glob',
+  Grep: 'tool-grep',
+  WebFetch: 'tool-web',
+  WebSearch: 'tool-web',
+  Task: 'tool-task',
+  TodoWrite: 'tool-task'
+}
+
+const currentToolExplanation = computed(() => {
+  const tool = claudeStore.currentTool
+  return tool ? toolDescriptions[tool] : null
+})
+
+const currentToolColor = computed(() => {
+  const tool = claudeStore.currentTool
+  return tool ? toolColors[tool] || '' : ''
+})
+
+// Determine detail level based on skill
+const showDetailedExplanations = computed(() => {
+  return settingsStore.skillLevel === 'beginner'
+})
+
+function openToolsGuide() {
+  uiStore.setTrack('claude-code')
+  uiStore.setCurrentGuide('claude-3')
+}
+
+function openActivityTab() {
+  uiStore.setActiveTab('activity')
+}
+</script>
+
+<template>
+  <div v-if="claudeStore.isClaudeSession" class="claude-activity-panel">
+    <div class="activity-header">
+      <span class="activity-title">Claude is working</span>
+      <div class="header-links">
+        <button @click="openActivityTab" class="link-btn" title="View full activity history">
+          History
+        </button>
+        <button @click="openToolsGuide" class="link-btn">
+          What is this?
+        </button>
+      </div>
+    </div>
+
+    <!-- Current Activity -->
+    <div class="current-activity">
+      <!-- Thinking State -->
+      <div v-if="claudeStore.isThinking" class="thinking-indicator">
+        <span class="spinner"></span>
+        <span class="thinking-text">Thinking...</span>
+      </div>
+
+      <!-- Tool Activity -->
+      <div v-else-if="claudeStore.currentTool" class="tool-activity">
+        <div class="tool-badge" :class="currentToolColor">
+          {{ claudeStore.currentTool }}
+        </div>
+        <p v-if="showDetailedExplanations" class="tool-explanation">
+          {{ currentToolExplanation }}
+        </p>
+        <p v-if="claudeStore.currentActivity?.description" class="tool-detail">
+          {{ claudeStore.currentActivity.description }}
+        </p>
+      </div>
+
+      <!-- Idle State -->
+      <div v-else class="idle-state">
+        <span>Waiting for Claude's response...</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.claude-activity-panel {
+  background: linear-gradient(135deg, #f5f3ff 0%, #ede9fe 100%);
+  border: 1px solid #ddd6fe;
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-top: 12px;
+}
+
+.activity-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.activity-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #5b21b6;
+}
+
+.header-links {
+  display: flex;
+  gap: 12px;
+}
+
+.link-btn {
+  font-size: 11px;
+  color: #7c3aed;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.link-btn:hover {
+  color: #5b21b6;
+}
+
+.current-activity {
+  background: white;
+  border-radius: 6px;
+  padding: 8px 10px;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+}
+
+/* Thinking State */
+.thinking-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #ddd6fe;
+  border-top-color: #7c3aed;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.thinking-text {
+  font-size: 12px;
+  color: #6b7280;
+  font-style: italic;
+}
+
+/* Tool Activity */
+.tool-activity {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.tool-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.tool-read {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.tool-write {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.tool-edit {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.tool-bash {
+  background: #fce7f3;
+  color: #be185d;
+}
+
+.tool-glob, .tool-grep {
+  background: #e0e7ff;
+  color: #4338ca;
+}
+
+.tool-web {
+  background: #cffafe;
+  color: #0e7490;
+}
+
+.tool-task {
+  background: #f3e8ff;
+  color: #7e22ce;
+}
+
+.tool-explanation {
+  font-size: 11px;
+  color: #6b7280;
+  margin: 0;
+}
+
+.tool-detail {
+  font-size: 11px;
+  color: #9ca3af;
+  margin: 0;
+  font-family: 'Menlo', 'Monaco', monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+/* Idle State */
+.idle-state {
+  font-size: 12px;
+  color: #9ca3af;
+  font-style: italic;
+}
+</style>

--- a/src/components/DraftPanel.vue
+++ b/src/components/DraftPanel.vue
@@ -587,7 +587,7 @@ watch(inputRef, (el) => {
         <div v-else-if="claudeStore.currentTool" class="activity-state tool">
           <span class="tool-badge" :class="toolColorClass">{{ claudeStore.currentTool }}</span>
           <span v-if="settingsStore.skillLevel === 'beginner'" class="tool-explanation">
-            {{ toolExplanations[claudeStore.currentTool] }}
+            {{ toolExplanations[claudeStore.currentTool] ?? 'Claude is using a tool.' }}
           </span>
           <span v-if="claudeStore.currentActivity?.description" class="tool-detail">
             {{ claudeStore.currentActivity.description }}

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -54,10 +54,10 @@ function switchTab(tab: InfoPanelTab) {
 }
 
 // Tab configuration
-const tabs: Array<{ id: InfoPanelTab; label: string; icon: string }> = [
-  { id: 'guides', label: 'Guides', icon: 'book' },
-  { id: 'activity', label: 'Activity', icon: 'activity' },
-  { id: 'notes', label: 'Notes', icon: 'edit' }
+const tabs: Array<{ id: InfoPanelTab; label: string }> = [
+  { id: 'guides', label: 'Guides' },
+  { id: 'activity', label: 'Activity' },
+  { id: 'notes', label: 'Notes' }
 ]
 </script>
 

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -1,13 +1,39 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useUIStore } from '../stores/ui'
+import { useUIStore, type InfoPanelTab } from '../stores/ui'
+import { useSettingsStore } from '../stores/settings'
+import { useClaudeStore } from '../stores/claude'
 import { guides, getGuide } from '../guides'
+import { claudeGuides, getClaudeGuide } from '../guides/claude-code'
+import ActivityHistoryView from './ActivityHistoryView.vue'
+import NotesPanel from './NotesPanel.vue'
 
 const uiStore = useUIStore()
+const settingsStore = useSettingsStore()
+const claudeStore = useClaudeStore()
 
+// Check if user can access Claude Code guides (intermediate or advanced)
+const canAccessClaudeGuides = computed(() => {
+  return settingsStore.skillLevel !== 'beginner'
+})
+
+// Get current guide based on active track
 const currentGuide = computed(() => {
   if (!uiStore.currentGuideId) return null
+  if (uiStore.currentTrack === 'claude-code') {
+    return getClaudeGuide(uiStore.currentGuideId) || null
+  }
   return getGuide(uiStore.currentGuideId) || null
+})
+
+// Get guides list based on active track
+const activeGuides = computed(() => {
+  return uiStore.currentTrack === 'claude-code' ? claudeGuides : guides
+})
+
+// Show activity indicator when Claude is running
+const showActivityIndicator = computed(() => {
+  return claudeStore.isClaudeSession && uiStore.activeTab !== 'activity'
 })
 
 function selectGuide(guideId: string) {
@@ -17,6 +43,22 @@ function selectGuide(guideId: string) {
 function goToIndex() {
   uiStore.showGuidesIndex()
 }
+
+function switchTrack(track: 'terminal' | 'claude-code') {
+  if (track === 'claude-code' && !canAccessClaudeGuides.value) return
+  uiStore.setTrack(track)
+}
+
+function switchTab(tab: InfoPanelTab) {
+  uiStore.setActiveTab(tab)
+}
+
+// Tab configuration
+const tabs: Array<{ id: InfoPanelTab; label: string; icon: string }> = [
+  { id: 'guides', label: 'Guides', icon: 'book' },
+  { id: 'activity', label: 'Activity', icon: 'activity' },
+  { id: 'notes', label: 'Notes', icon: 'edit' }
+]
 </script>
 
 <template>
@@ -29,54 +71,115 @@ function goToIndex() {
       {{ uiStore.showInfoPanel ? '›' : '‹' }}
     </button>
     <div class="panel-content" v-show="uiStore.showInfoPanel">
-      <!-- Guide Content View -->
-      <template v-if="currentGuide">
-        <div class="panel-header">
-          <button class="back-btn" @click="goToIndex" title="Back to guides">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M19 12H5M12 19l-7-7 7-7"/>
-            </svg>
-          </button>
-          <div class="panel-title-group">
-            <span class="panel-title">{{ currentGuide.title }}</span>
-            <span v-if="currentGuide.subtitle" class="panel-subtitle">{{ currentGuide.subtitle }}</span>
-          </div>
-          <button class="menu-btn" @click="goToIndex" title="All guides">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <line x1="3" y1="6" x2="21" y2="6"/>
-              <line x1="3" y1="12" x2="21" y2="12"/>
-              <line x1="3" y1="18" x2="21" y2="18"/>
-            </svg>
-          </button>
-        </div>
-        <div class="guide-content" v-html="currentGuide.content"></div>
-      </template>
+      <!-- Top-Level Tabs -->
+      <div class="top-tabs">
+        <button
+          v-for="tab in tabs"
+          :key="tab.id"
+          class="top-tab"
+          :class="{
+            active: uiStore.activeTab === tab.id,
+            'has-indicator': tab.id === 'activity' && showActivityIndicator
+          }"
+          @click="switchTab(tab.id)"
+        >
+          <span class="tab-label">{{ tab.label }}</span>
+          <span v-if="tab.id === 'activity' && showActivityIndicator" class="activity-dot"></span>
+        </button>
+      </div>
 
-      <!-- Guides Index View -->
-      <template v-else>
-        <div class="panel-header">
-          <span class="panel-title">Guides</span>
-        </div>
-        <div class="guides-index">
-          <p class="index-intro">Learn the command line step by step.</p>
-          <div class="guide-list">
-            <button
-              v-for="guide in guides"
-              :key="guide.id"
-              class="guide-card"
-              @click="selectGuide(guide.id)"
-            >
-              <div class="guide-card-text">
-                <span class="guide-card-title">{{ guide.title }}</span>
-                <span v-if="guide.subtitle" class="guide-card-subtitle">{{ guide.subtitle }}</span>
-              </div>
+      <!-- Guides Tab Content -->
+      <div v-if="uiStore.activeTab === 'guides'" class="tab-content guides-tab">
+        <!-- Guide Content View -->
+        <template v-if="currentGuide">
+          <div class="panel-header">
+            <button class="back-btn" @click="goToIndex" title="Back to guides">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M5 12h14M12 5l7 7-7 7"/>
+                <path d="M19 12H5M12 19l-7-7 7-7"/>
+              </svg>
+            </button>
+            <div class="panel-title-group">
+              <span class="panel-title">{{ currentGuide.title }}</span>
+              <span v-if="currentGuide.subtitle" class="panel-subtitle">{{ currentGuide.subtitle }}</span>
+            </div>
+            <button class="menu-btn" @click="goToIndex" title="All guides">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="3" y1="6" x2="21" y2="6"/>
+                <line x1="3" y1="12" x2="21" y2="12"/>
+                <line x1="3" y1="18" x2="21" y2="18"/>
               </svg>
             </button>
           </div>
-        </div>
-      </template>
+          <div class="guide-content" v-html="currentGuide.content"></div>
+        </template>
+
+        <!-- Guides Index View -->
+        <template v-else>
+          <div class="panel-header">
+            <span class="panel-title">Guides</span>
+          </div>
+
+          <!-- Track Tabs -->
+          <div class="track-tabs">
+            <button
+              class="track-tab"
+              :class="{ active: uiStore.currentTrack === 'terminal' }"
+              @click="switchTrack('terminal')"
+            >
+              Terminal Basics
+            </button>
+            <button
+              class="track-tab"
+              :class="{
+                active: uiStore.currentTrack === 'claude-code',
+                locked: !canAccessClaudeGuides
+              }"
+              @click="switchTrack('claude-code')"
+              :title="!canAccessClaudeGuides ? 'Unlock by changing to Intermediate or Advanced in Settings' : ''"
+            >
+              <span>Claude Code</span>
+              <svg v-if="!canAccessClaudeGuides" class="lock-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+                <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+              </svg>
+            </button>
+          </div>
+
+          <div class="guides-index">
+            <p class="index-intro">
+              {{ uiStore.currentTrack === 'claude-code'
+                 ? 'Learn to use Claude Code, your AI coding partner.'
+                 : 'Learn the command line step by step.' }}
+            </p>
+            <div class="guide-list">
+              <button
+                v-for="guide in activeGuides"
+                :key="guide.id"
+                class="guide-card"
+                @click="selectGuide(guide.id)"
+              >
+                <div class="guide-card-text">
+                  <span class="guide-card-title">{{ guide.title }}</span>
+                  <span v-if="guide.subtitle" class="guide-card-subtitle">{{ guide.subtitle }}</span>
+                </div>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M5 12h14M12 5l7 7-7 7"/>
+                </svg>
+              </button>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- Activity Tab Content -->
+      <div v-else-if="uiStore.activeTab === 'activity'" class="tab-content activity-tab">
+        <ActivityHistoryView />
+      </div>
+
+      <!-- Notes Tab Content -->
+      <div v-else-if="uiStore.activeTab === 'notes'" class="tab-content notes-tab">
+        <NotesPanel />
+      </div>
     </div>
   </div>
 </template>
@@ -124,7 +227,7 @@ function goToIndex() {
 
 .panel-content {
   flex: 1;
-  padding: 16px 16px 16px 32px;
+  padding: 12px 16px 16px 32px;
   overflow-y: auto;
   scrollbar-width: thin;
   display: flex;
@@ -138,6 +241,77 @@ function goToIndex() {
 .panel-content::-webkit-scrollbar-thumb {
   background: #d1d5db;
   border-radius: 3px;
+}
+
+/* Top-Level Tabs */
+.top-tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 16px;
+  background: #e5e7eb;
+  border-radius: 8px;
+  padding: 3px;
+}
+
+.top-tab {
+  flex: 1;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  position: relative;
+}
+
+.top-tab:hover {
+  color: #374151;
+}
+
+.top-tab.active {
+  background: white;
+  color: #111827;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.activity-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #22c55e;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* Tab Content */
+.tab-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.guides-tab {
+  overflow-y: auto;
+}
+
+.activity-tab {
+  overflow: hidden;
+}
+
+.notes-tab {
+  overflow: hidden;
 }
 
 /* Header */
@@ -206,6 +380,52 @@ function goToIndex() {
   background: #f3f4f6;
   border-color: #e5e7eb;
   color: #374151;
+}
+
+/* Track Tabs */
+.track-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+  background: #f3f4f6;
+  border-radius: 8px;
+  padding: 4px;
+}
+
+.track-tab {
+  flex: 1;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.track-tab:hover:not(.locked) {
+  color: #374151;
+}
+
+.track-tab.active {
+  background: white;
+  color: #111827;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.track-tab.locked {
+  color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.track-tab .lock-icon {
+  opacity: 0.6;
 }
 
 /* Guides Index */

--- a/src/components/NotesPanel.vue
+++ b/src/components/NotesPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, onMounted } from 'vue'
+import { ref, watch, onMounted, onUnmounted } from 'vue'
 import { useUIStore } from '../stores/ui'
 
 const uiStore = useUIStore()
@@ -19,6 +19,11 @@ watch(localNotes, (newValue) => {
   saveTimeout = setTimeout(() => {
     uiStore.setUserNotes(newValue)
   }, 500)
+})
+
+// Clean up timeout on unmount to prevent memory leak
+onUnmounted(() => {
+  if (saveTimeout) clearTimeout(saveTimeout)
 })
 
 function clearNotes() {

--- a/src/components/NotesPanel.vue
+++ b/src/components/NotesPanel.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { ref, watch, onMounted } from 'vue'
+import { useUIStore } from '../stores/ui'
+
+const uiStore = useUIStore()
+const localNotes = ref('')
+const textareaRef = ref<HTMLTextAreaElement | null>(null)
+
+// Sync with store on mount
+onMounted(() => {
+  localNotes.value = uiStore.userNotes
+})
+
+// Debounced save to store
+let saveTimeout: ReturnType<typeof setTimeout> | null = null
+
+watch(localNotes, (newValue) => {
+  if (saveTimeout) clearTimeout(saveTimeout)
+  saveTimeout = setTimeout(() => {
+    uiStore.setUserNotes(newValue)
+  }, 500)
+})
+
+function clearNotes() {
+  localNotes.value = ''
+  uiStore.setUserNotes('')
+  textareaRef.value?.focus()
+}
+</script>
+
+<template>
+  <div class="notes-panel">
+    <div class="notes-header">
+      <span class="notes-title">Session Notes</span>
+      <button
+        v-if="localNotes.trim()"
+        @click="clearNotes"
+        class="clear-btn"
+        title="Clear all notes"
+      >
+        Clear
+      </button>
+    </div>
+    <textarea
+      ref="textareaRef"
+      v-model="localNotes"
+      class="notes-textarea"
+      placeholder="Jot down notes during your session...
+
+Ideas:
+- Commands you want to remember
+- Things you learned
+- Questions to explore later"
+    ></textarea>
+    <div class="notes-footer">
+      <span class="char-count">{{ localNotes.length }} characters</span>
+      <span v-if="localNotes.trim()" class="auto-saved">Auto-saved</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.notes-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.notes-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.notes-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.clear-btn {
+  font-size: 12px;
+  color: #6b7280;
+  background: none;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.clear-btn:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #374151;
+}
+
+.notes-textarea {
+  flex: 1;
+  width: 100%;
+  min-height: 200px;
+  padding: 12px;
+  font-size: 13px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+  color: #374151;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  resize: none;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.notes-textarea:focus {
+  border-color: #9ca3af;
+}
+
+.notes-textarea::placeholder {
+  color: #9ca3af;
+}
+
+.notes-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+  font-size: 11px;
+  color: #9ca3af;
+}
+
+.auto-saved {
+  color: #22c55e;
+}
+</style>

--- a/src/components/TerminalView.vue
+++ b/src/components/TerminalView.vue
@@ -4,11 +4,13 @@ import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { useSettingsStore } from '../stores/settings'
 import { useTerminalStore } from '../stores/terminal'
+import { useClaudeStore } from '../stores/claude'
 import '@xterm/xterm/css/xterm.css'
 
 const terminalContainer = ref<HTMLDivElement | null>(null)
 const settingsStore = useSettingsStore()
 const terminalStore = useTerminalStore()
+const claudeStore = useClaudeStore()
 let terminal: Terminal | null = null
 let fitAddon: FitAddon | null = null
 let inputDisposable: { dispose: () => void } | null = null
@@ -87,6 +89,8 @@ onMounted(() => {
     terminal?.scrollToBottom()
     // Process output to detect prompts and mode changes
     terminalStore.processPtyOutput(data)
+    // Process output for Claude session detection
+    claudeStore.processClaudeOutput(data)
   })
 
   window.electron.pty.onExit((code) => {

--- a/src/data/commands.json
+++ b/src/data/commands.json
@@ -358,5 +358,24 @@
     "description": "Create command shortcut",
     "safety": "safe",
     "flags": {}
+  },
+  "claude": {
+    "description": "Start Claude Code AI assistant",
+    "safety": "safe",
+    "flags": {
+      "--help": "show help and available options",
+      "-h": "show help (short form)",
+      "--version": "show installed version",
+      "-v": "show version (short form)",
+      "-p": "print mode (non-interactive)",
+      "--print": "print mode (non-interactive)",
+      "-c": "continue last conversation",
+      "--continue": "continue last conversation",
+      "-r": "resume a specific conversation",
+      "--resume": "resume a specific conversation",
+      "--allowedTools": "restrict which tools Claude can use",
+      "--model": "specify which Claude model to use",
+      "--dangerously-skip-permissions": "skip permission prompts (advanced users only)"
+    }
   }
 }

--- a/src/data/commands.json
+++ b/src/data/commands.json
@@ -375,7 +375,7 @@
       "--resume": "resume a specific conversation",
       "--allowedTools": "restrict which tools Claude can use",
       "--model": "specify which Claude model to use",
-      "--dangerously-skip-permissions": "skip permission prompts (advanced users only)"
+      "--dangerously-skip-permissions": "DANGEROUS: disables permission prompts and may execute actions without confirmation. Can lead to unsafe or destructive operations. Use only if you fully understand and accept the risks."
     }
   }
 }

--- a/src/guides/claude-code/claude-1-intro.html
+++ b/src/guides/claude-code/claude-1-intro.html
@@ -1,0 +1,74 @@
+<h2>Getting Started with Claude Code</h2>
+
+<p>
+  Claude Code is an AI assistant that lives in your terminal.
+  It can help you write code, understand projects, fix bugs, and run commands.
+</p>
+
+<section>
+  <h3>What is Claude Code?</h3>
+  <p>
+    Think of Claude Code as a knowledgeable programming partner that can:
+  </p>
+  <ul>
+    <li>Read and understand your code files</li>
+    <li>Write and edit code for you</li>
+    <li>Run terminal commands on your behalf</li>
+    <li>Search the web for documentation</li>
+    <li>Explain what's happening step by step</li>
+  </ul>
+</section>
+
+<section>
+  <h3>Installing Claude Code</h3>
+  <p>
+    If you don't have Claude Code installed yet, run this command:
+  </p>
+  <div class="command-example">
+    <code>npm install -g @anthropic-ai/claude-code</code>
+    <p>Installs Claude Code globally on your system</p>
+  </div>
+  <p>
+    You'll need an Anthropic API key. Claude will prompt you to set it up on first run.
+  </p>
+</section>
+
+<section>
+  <h3>Starting Claude</h3>
+  <p>
+    There are two ways to use Claude Code:
+  </p>
+  <div class="command-example">
+    <code>claude</code>
+    <p>Start an interactive session — have a back-and-forth conversation</p>
+  </div>
+  <div class="command-example">
+    <code>claude "your question here"</code>
+    <p>Ask a one-off question — get an answer and return to your prompt</p>
+  </div>
+</section>
+
+<section>
+  <h3>Your First Interaction</h3>
+  <p>
+    Try starting Claude with a simple request:
+  </p>
+  <div class="command-example">
+    <code>claude "what files are in this directory?"</code>
+    <p>Claude will look at your files and describe what it finds</p>
+  </div>
+  <p>
+    Watch what happens — Claude will show you when it uses tools like
+    reading files or running commands. Everything is transparent.
+  </p>
+</section>
+
+<section>
+  <h3>Key Things to Know</h3>
+  <ul>
+    <li><strong>Claude asks permission</strong> — Before making changes, Claude will ask</li>
+    <li><strong>You can say no</strong> — Deny any action you're unsure about</li>
+    <li><strong>It's reversible</strong> — Use git to undo changes if needed</li>
+    <li><strong>Start small</strong> — Begin with questions before asking for edits</li>
+  </ul>
+</section>

--- a/src/guides/claude-code/claude-2-conversations.html
+++ b/src/guides/claude-code/claude-2-conversations.html
@@ -1,0 +1,83 @@
+<h2>Having Conversations with Claude</h2>
+
+<p>
+  Claude Code's interactive mode lets you have natural back-and-forth conversations
+  while working on your code.
+</p>
+
+<section>
+  <h3>Starting Interactive Mode</h3>
+  <p>
+    Type <kbd>claude</kbd> with no arguments to start a conversation:
+  </p>
+  <div class="command-example">
+    <code>claude</code>
+    <p>Opens an interactive session in your current directory</p>
+  </div>
+  <p>
+    You'll see Claude's prompt. Now you can type questions or requests naturally.
+  </p>
+</section>
+
+<section>
+  <h3>Asking Questions</h3>
+  <p>
+    In interactive mode, just type what you want to know:
+  </p>
+  <ul>
+    <li>"What does this project do?"</li>
+    <li>"Explain the main function in app.js"</li>
+    <li>"Why is this test failing?"</li>
+    <li>"How do I add a new route?"</li>
+  </ul>
+  <p>
+    Claude will read relevant files to give you informed answers.
+  </p>
+</section>
+
+<section>
+  <h3>Context Awareness</h3>
+  <p>
+    Claude remembers your conversation. You can refer back to earlier topics:
+  </p>
+  <ul>
+    <li>"Now fix the bug we discussed"</li>
+    <li>"Add tests for that function"</li>
+    <li>"Actually, use TypeScript instead"</li>
+  </ul>
+</section>
+
+<section>
+  <h3>Continuing Later</h3>
+  <p>
+    Resume your last conversation:
+  </p>
+  <div class="command-example">
+    <code>claude -c</code>
+    <p>Continue from where you left off</p>
+  </div>
+  <div class="command-example">
+    <code>claude -r</code>
+    <p>Pick from a list of past conversations to resume</p>
+  </div>
+</section>
+
+<section>
+  <h3>Exiting</h3>
+  <p>
+    When you're done, type one of these:
+  </p>
+  <ul>
+    <li><kbd>/exit</kbd> or <kbd>/quit</kbd> — Leave interactive mode</li>
+    <li><kbd>Ctrl</kbd>+<kbd>C</kbd> — Also exits (or stops current action)</li>
+  </ul>
+</section>
+
+<section>
+  <h3>Tips for Good Conversations</h3>
+  <ul>
+    <li><strong>Be specific</strong> — "Fix the login bug" is better than "fix bugs"</li>
+    <li><strong>Give context</strong> — Mention file names or function names when relevant</li>
+    <li><strong>Iterate</strong> — If the first answer isn't right, clarify what you need</li>
+  </ul>
+</section>

--- a/src/guides/claude-code/claude-3-tools.html
+++ b/src/guides/claude-code/claude-3-tools.html
@@ -1,0 +1,89 @@
+<h2>Understanding Claude's Tools</h2>
+
+<p>
+  Claude Code uses "tools" to interact with your computer.
+  When you see Claude using a tool, it's being transparent about what it's doing.
+</p>
+
+<section>
+  <h3>What Are Tools?</h3>
+  <p>
+    Tools are specific actions Claude can take. Instead of just talking,
+    Claude can actually read files, write code, and run commands.
+  </p>
+  <p>
+    You'll see tool names appear as Claude works — this is good!
+    It means you can see exactly what's happening.
+  </p>
+</section>
+
+<section>
+  <h3>Reading Tools</h3>
+  <div class="safety-item">
+    <span class="safety-dot safe"></span>
+    <span><strong>Read</strong> — Opens and reads a file's contents</span>
+  </div>
+  <div class="safety-item">
+    <span class="safety-dot safe"></span>
+    <span><strong>Glob</strong> — Finds files matching a pattern (like *.js)</span>
+  </div>
+  <div class="safety-item">
+    <span class="safety-dot safe"></span>
+    <span><strong>Grep</strong> — Searches file contents for specific text</span>
+  </div>
+  <p>
+    These tools only look at things — they don't change anything.
+  </p>
+</section>
+
+<section>
+  <h3>Writing Tools</h3>
+  <div class="safety-item">
+    <span class="safety-dot moderate"></span>
+    <span><strong>Write</strong> — Creates a new file or replaces an existing one</span>
+  </div>
+  <div class="safety-item">
+    <span class="safety-dot moderate"></span>
+    <span><strong>Edit</strong> — Makes targeted changes to part of a file</span>
+  </div>
+  <p>
+    These tools modify your code. Claude will show you what it plans to change
+    and ask for permission first.
+  </p>
+</section>
+
+<section>
+  <h3>Command Tools</h3>
+  <div class="safety-item">
+    <span class="safety-dot moderate"></span>
+    <span><strong>Bash</strong> — Runs a terminal command</span>
+  </div>
+  <p>
+    Claude can run commands like <code>npm install</code> or <code>git status</code>.
+    It will show you the command before running it.
+  </p>
+</section>
+
+<section>
+  <h3>Research Tools</h3>
+  <div class="safety-item">
+    <span class="safety-dot safe"></span>
+    <span><strong>WebSearch</strong> — Searches the web for information</span>
+  </div>
+  <div class="safety-item">
+    <span class="safety-dot safe"></span>
+    <span><strong>WebFetch</strong> — Retrieves content from a specific URL</span>
+  </div>
+  <p>
+    Claude can look up documentation, examples, or current information online.
+  </p>
+</section>
+
+<section>
+  <h3>Why This Matters</h3>
+  <p>
+    Seeing the tools helps you understand what Claude is doing and why.
+    If you see Claude using <strong>Read</strong> on several files before answering,
+    it's gathering context. If you see <strong>Edit</strong>, it's about to change code.
+  </p>
+</section>

--- a/src/guides/claude-code/claude-4-workflows.html
+++ b/src/guides/claude-code/claude-4-workflows.html
@@ -1,0 +1,100 @@
+<h2>Common Workflows</h2>
+
+<p>
+  Here are practical patterns for using Claude Code effectively in everyday development.
+</p>
+
+<section>
+  <h3>Exploring a New Codebase</h3>
+  <p>
+    When you're new to a project, ask Claude to orient you:
+  </p>
+  <ul>
+    <li>"What does this project do?"</li>
+    <li>"Where is the main entry point?"</li>
+    <li>"Explain the folder structure"</li>
+    <li>"What technologies does this use?"</li>
+  </ul>
+  <p>
+    Claude will read files and give you a summary tailored to developers.
+  </p>
+</section>
+
+<section>
+  <h3>Debugging</h3>
+  <p>
+    Describe the problem and let Claude investigate:
+  </p>
+  <ul>
+    <li>"This function returns undefined when it shouldn't"</li>
+    <li>"The tests are failing with this error: [paste error]"</li>
+    <li>"Why is the API returning 500?"</li>
+  </ul>
+  <p>
+    Claude will trace through the code, identify the issue, and suggest a fix.
+  </p>
+</section>
+
+<section>
+  <h3>Adding Features</h3>
+  <p>
+    Start by describing what you want at a high level:
+  </p>
+  <ul>
+    <li>"Add a logout button to the header"</li>
+    <li>"Create an endpoint that returns user stats"</li>
+    <li>"Add dark mode support"</li>
+  </ul>
+  <p>
+    Claude will figure out where to make changes and how to fit with existing patterns.
+  </p>
+</section>
+
+<section>
+  <h3>Refactoring</h3>
+  <p>
+    Ask for specific improvements:
+  </p>
+  <ul>
+    <li>"Extract this logic into a reusable hook"</li>
+    <li>"Convert this file to TypeScript"</li>
+    <li>"Split this large component into smaller ones"</li>
+  </ul>
+</section>
+
+<section>
+  <h3>Writing Tests</h3>
+  <p>
+    Claude can write tests for existing code:
+  </p>
+  <ul>
+    <li>"Add unit tests for the UserService class"</li>
+    <li>"Write a test for the edge case where input is empty"</li>
+    <li>"Generate tests covering the main user flows"</li>
+  </ul>
+</section>
+
+<section>
+  <h3>Documentation</h3>
+  <p>
+    Get help writing docs:
+  </p>
+  <ul>
+    <li>"Add JSDoc comments to the public functions"</li>
+    <li>"Write a README for this project"</li>
+    <li>"Document how to set up the development environment"</li>
+  </ul>
+</section>
+
+<section>
+  <h3>Best Practice: Start Small</h3>
+  <p>
+    For complex changes, break them into steps:
+  </p>
+  <ol>
+    <li>Ask Claude to explain the current state</li>
+    <li>Discuss the approach before implementing</li>
+    <li>Make changes incrementally</li>
+    <li>Test after each step</li>
+  </ol>
+</section>

--- a/src/guides/claude-code/claude-5-permissions.html
+++ b/src/guides/claude-code/claude-5-permissions.html
@@ -1,0 +1,102 @@
+<h2>Understanding Permissions</h2>
+
+<p>
+  Claude Code asks for permission before making changes.
+  This keeps you in control of what happens to your code.
+</p>
+
+<section>
+  <h3>The Permission Prompt</h3>
+  <p>
+    When Claude wants to do something that changes files or runs commands,
+    you'll see a prompt asking for approval. You can:
+  </p>
+  <ul>
+    <li><strong>Allow</strong> — Let Claude proceed with this action</li>
+    <li><strong>Deny</strong> — Stop this action from happening</li>
+    <li><strong>Allow All</strong> — Trust this type of action for the session</li>
+  </ul>
+</section>
+
+<section>
+  <h3>What Requires Permission</h3>
+  <div class="safety-item">
+    <span class="safety-dot moderate"></span>
+    <span>Writing or editing files</span>
+  </div>
+  <div class="safety-item">
+    <span class="safety-dot moderate"></span>
+    <span>Running terminal commands</span>
+  </div>
+  <div class="safety-item">
+    <span class="safety-dot dangerous"></span>
+    <span>Commands that could have wide impact (like <code>rm -rf</code>)</span>
+  </div>
+</section>
+
+<section>
+  <h3>What Doesn't Require Permission</h3>
+  <div class="safety-item">
+    <span class="safety-dot safe"></span>
+    <span>Reading files</span>
+  </div>
+  <div class="safety-item">
+    <span class="safety-dot safe"></span>
+    <span>Searching for files or content</span>
+  </div>
+  <div class="safety-item">
+    <span class="safety-dot safe"></span>
+    <span>Looking up documentation online</span>
+  </div>
+  <p>
+    Read-only operations are generally allowed without prompting.
+  </p>
+</section>
+
+<section>
+  <h3>When to Deny</h3>
+  <p>
+    Say no when:
+  </p>
+  <ul>
+    <li>You want to review the change first</li>
+    <li>The action doesn't match what you asked for</li>
+    <li>You want to try a different approach</li>
+    <li>You're not sure what the command does</li>
+  </ul>
+  <p>
+    It's always okay to deny and ask Claude to explain first.
+  </p>
+</section>
+
+<section>
+  <h3>Trusting Actions</h3>
+  <p>
+    If you're doing repetitive work, you can allow entire categories:
+  </p>
+  <ul>
+    <li>"Allow all file edits" — Useful when refactoring</li>
+    <li>"Allow all bash commands" — Useful for build/test cycles</li>
+  </ul>
+  <p>
+    These permissions last only for your current session.
+  </p>
+</section>
+
+<section>
+  <h3>Safety Net: Git</h3>
+  <p>
+    Always work in a git repository. If something goes wrong:
+  </p>
+  <div class="command-example">
+    <code>git diff</code>
+    <p>See what changed</p>
+  </div>
+  <div class="command-example">
+    <code>git checkout .</code>
+    <p>Undo all uncommitted changes</p>
+  </div>
+  <p>
+    Commit before big changes so you have a restore point.
+  </p>
+</section>

--- a/src/guides/claude-code/claude-6-best-practices.html
+++ b/src/guides/claude-code/claude-6-best-practices.html
@@ -1,0 +1,102 @@
+<h2>Best Practices</h2>
+
+<p>
+  Get better results from Claude Code by following these patterns.
+</p>
+
+<section>
+  <h3>Be Specific</h3>
+  <p>
+    Good prompts include context:
+  </p>
+  <ul>
+    <li><strong>Less helpful:</strong> "Fix the bug"</li>
+    <li><strong>More helpful:</strong> "Fix the null pointer error in UserService.getProfile()"</li>
+  </ul>
+  <p>
+    Mention file names, function names, error messages, and expected behavior.
+  </p>
+</section>
+
+<section>
+  <h3>Review Changes Before Accepting</h3>
+  <p>
+    When Claude shows you a diff (the changes it wants to make):
+  </p>
+  <ul>
+    <li>Read through the changes</li>
+    <li>Make sure they match what you asked for</li>
+    <li>Check that nothing unexpected is being modified</li>
+  </ul>
+  <p>
+    It's faster to catch issues before accepting than to fix them after.
+  </p>
+</section>
+
+<section>
+  <h3>Iterate and Refine</h3>
+  <p>
+    If the first result isn't perfect, guide Claude:
+  </p>
+  <ul>
+    <li>"Good, but use async/await instead of callbacks"</li>
+    <li>"Can you make this more concise?"</li>
+    <li>"Actually, put that in a separate file"</li>
+  </ul>
+  <p>
+    Claude learns from your feedback within the conversation.
+  </p>
+</section>
+
+<section>
+  <h3>Use Git Commits as Checkpoints</h3>
+  <p>
+    Create commits between major changes:
+  </p>
+  <ol>
+    <li>Ask Claude to make a change</li>
+    <li>Review and test it</li>
+    <li>Commit if it works</li>
+    <li>Move to the next change</li>
+  </ol>
+  <p>
+    This gives you safe points to return to.
+  </p>
+</section>
+
+<section>
+  <h3>Let Claude Explore First</h3>
+  <p>
+    For unfamiliar codebases, ask questions before requesting changes:
+  </p>
+  <ul>
+    <li>"How does authentication work in this app?"</li>
+    <li>"What would be the best place to add this feature?"</li>
+    <li>"Are there existing patterns I should follow?"</li>
+  </ul>
+</section>
+
+<section>
+  <h3>Break Down Large Tasks</h3>
+  <p>
+    Instead of "Rewrite the entire auth system":
+  </p>
+  <ol>
+    <li>"Explain the current auth flow"</li>
+    <li>"What are the problems with it?"</li>
+    <li>"Design a better approach"</li>
+    <li>"Implement step 1 of the new design"</li>
+  </ol>
+</section>
+
+<section>
+  <h3>Trust But Verify</h3>
+  <p>
+    Claude is helpful but not perfect. Always:
+  </p>
+  <ul>
+    <li>Run your tests after changes</li>
+    <li>Check that the app still works</li>
+    <li>Read the code Claude wrote — you own it now</li>
+  </ul>
+</section>

--- a/src/guides/claude-code/index.ts
+++ b/src/guides/claude-code/index.ts
@@ -1,0 +1,60 @@
+export interface ClaudeGuide {
+  id: string
+  title: string
+  subtitle?: string
+  content: string
+}
+
+import claude1 from './claude-1-intro.html?raw'
+import claude2 from './claude-2-conversations.html?raw'
+import claude3 from './claude-3-tools.html?raw'
+import claude4 from './claude-4-workflows.html?raw'
+import claude5 from './claude-5-permissions.html?raw'
+import claude6 from './claude-6-best-practices.html?raw'
+
+export const claudeGuides: ClaudeGuide[] = [
+  {
+    id: 'claude-1',
+    title: 'Getting Started',
+    subtitle: 'your AI coding partner',
+    content: claude1
+  },
+  {
+    id: 'claude-2',
+    title: 'Conversations',
+    subtitle: 'interactive mode',
+    content: claude2
+  },
+  {
+    id: 'claude-3',
+    title: 'Understanding Tools',
+    subtitle: 'how Claude works',
+    content: claude3
+  },
+  {
+    id: 'claude-4',
+    title: 'Common Workflows',
+    subtitle: 'practical patterns',
+    content: claude4
+  },
+  {
+    id: 'claude-5',
+    title: 'Permissions',
+    subtitle: 'staying in control',
+    content: claude5
+  },
+  {
+    id: 'claude-6',
+    title: 'Best Practices',
+    subtitle: 'getting great results',
+    content: claude6
+  }
+]
+
+export function getClaudeGuide(id: string): ClaudeGuide | undefined {
+  return claudeGuides.find(g => g.id === id)
+}
+
+export function getDefaultClaudeGuide(): ClaudeGuide {
+  return claudeGuides[0]
+}

--- a/src/services/CommandParser.ts
+++ b/src/services/CommandParser.ts
@@ -99,7 +99,12 @@ function getArgumentType(arg: string): string {
 /**
  * Build a human-readable description of the full command
  */
-function buildDescription(_cmd: string, def: CommandDef, args: string[]): string {
+function buildDescription(cmd: string, def: CommandDef, args: string[]): string {
+  // Special handling for claude command
+  if (cmd === 'claude') {
+    return buildClaudeDescription(args)
+  }
+
   let desc = def.description
 
   // Add context based on arguments
@@ -115,6 +120,40 @@ function buildDescription(_cmd: string, def: CommandDef, args: string[]): string
   }
 
   return desc
+}
+
+/**
+ * Build description specifically for the claude command
+ */
+function buildClaudeDescription(args: string[]): string {
+  // Check for specific flags
+  const hasHelp = args.some(a => a === '--help' || a === '-h')
+  const hasVersion = args.some(a => a === '--version' || a === '-v')
+  const hasContinue = args.some(a => a === '-c' || a === '--continue')
+  const hasResume = args.some(a => a === '-r' || a === '--resume')
+  const hasPrint = args.some(a => a === '-p' || a === '--print')
+
+  if (hasHelp) return 'Show Claude Code help and available options'
+  if (hasVersion) return 'Show installed Claude Code version'
+  if (hasContinue) return 'Continue your last Claude conversation'
+  if (hasResume) return 'Resume a specific Claude conversation'
+
+  // Check for prompt argument (non-flag argument)
+  const promptArg = args.find(a => !a.startsWith('-'))
+  if (promptArg) {
+    const truncated = promptArg.length > 50 ? promptArg.substring(0, 50) + '...' : promptArg
+    if (hasPrint) {
+      return `Ask Claude (print mode): "${truncated}"`
+    }
+    return `Ask Claude a one-off question: "${truncated}"`
+  }
+
+  // Default: starting interactive session
+  if (args.length === 0) {
+    return 'Start an interactive Claude session in this directory'
+  }
+
+  return 'Start Claude Code AI assistant'
 }
 
 /**

--- a/src/stores/claude.ts
+++ b/src/stores/claude.ts
@@ -214,12 +214,15 @@ export const useClaudeStore = defineStore('claude', () => {
       const todoPattern = /\[?(pending|in_progress|completed)\]?\s*(.+)/gi
       const matches = [...clean.matchAll(todoPattern)]
       if (matches.length > 0) {
-        const parsedTodos: TodoItem[] = matches.map(m => ({
-          content: m[2].trim().substring(0, 60),
-          status: m[1].toLowerCase().replace('_', '_') as TodoItem['status'],
-          activities: [],
-          collapsed: false
-        }))
+        const parsedTodos: TodoItem[] = matches.map(m => {
+          const rawContent = m[2].trim()
+          return {
+            content: rawContent.length > 60 ? rawContent.substring(0, 60) + '...' : rawContent,
+            status: m[1].toLowerCase() as TodoItem['status'],
+            activities: [],
+            collapsed: false
+          }
+        })
         updateTodos(parsedTodos)
       }
     }

--- a/src/stores/claude.ts
+++ b/src/stores/claude.ts
@@ -1,0 +1,342 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export type ClaudeToolType =
+  | 'Read' | 'Write' | 'Edit' | 'Bash'
+  | 'Glob' | 'Grep' | 'WebFetch' | 'WebSearch'
+  | 'Task' | 'TodoWrite' | null
+
+export interface ClaudeActivity {
+  type: 'thinking' | 'tool_start' | 'tool_complete' | 'response' | 'error'
+  tool?: ClaudeToolType
+  description?: string
+  timestamp: number
+}
+
+export interface TodoItem {
+  content: string
+  status: 'pending' | 'in_progress' | 'completed'
+  activities: ClaudeActivity[]
+  collapsed: boolean
+}
+
+export interface ConversationRound {
+  id: string
+  promptSummary: string
+  timestamp: number
+  todos: TodoItem[]
+  activities: ClaudeActivity[] // Activities not tied to a specific todo
+  collapsed: boolean
+}
+
+export const useClaudeStore = defineStore('claude', () => {
+  // State
+  const isClaudeSession = ref(false)
+  const currentActivity = ref<ClaudeActivity | null>(null)
+  const sessionStartTime = ref<number | null>(null)
+
+  // Hierarchical activity tracking
+  const conversationRounds = ref<ConversationRound[]>([])
+  const currentRoundId = ref<string | null>(null)
+  const currentTodos = ref<TodoItem[]>([])
+
+  // Legacy flat history (for compatibility)
+  const activityHistory = ref<ClaudeActivity[]>([])
+
+  // Computed
+  const isThinking = computed(() =>
+    currentActivity.value?.type === 'thinking'
+  )
+
+  const currentTool = computed(() =>
+    currentActivity.value?.tool || null
+  )
+
+  const currentRound = computed(() =>
+    conversationRounds.value.find(r => r.id === currentRoundId.value) || null
+  )
+
+  const recentActivities = computed(() =>
+    activityHistory.value.slice(-10).reverse()
+  )
+
+  // Get active todo (the one marked in_progress)
+  const activeTodo = computed(() =>
+    currentTodos.value.find(t => t.status === 'in_progress') || null
+  )
+
+  // Actions
+  function startSession() {
+    isClaudeSession.value = true
+    sessionStartTime.value = Date.now()
+    activityHistory.value = []
+    conversationRounds.value = []
+    currentRoundId.value = null
+    currentTodos.value = []
+    currentActivity.value = null
+  }
+
+  function endSession() {
+    isClaudeSession.value = false
+    currentActivity.value = null
+    sessionStartTime.value = null
+    currentRoundId.value = null
+    currentTodos.value = []
+  }
+
+  function startNewRound(promptSummary: string = 'User prompt') {
+    const round: ConversationRound = {
+      id: `round-${Date.now()}`,
+      promptSummary,
+      timestamp: Date.now(),
+      todos: [],
+      activities: [],
+      collapsed: false
+    }
+    conversationRounds.value.push(round)
+    currentRoundId.value = round.id
+    currentTodos.value = []
+  }
+
+  function updateTodos(todos: TodoItem[]) {
+    currentTodos.value = todos
+    // Also update the current round's todos
+    if (currentRound.value) {
+      currentRound.value.todos = todos
+    }
+  }
+
+  function setActivity(activity: ClaudeActivity) {
+    currentActivity.value = activity
+    activityHistory.value.push(activity)
+
+    // Keep last 100 activities in flat list
+    if (activityHistory.value.length > 100) {
+      activityHistory.value.shift()
+    }
+
+    // Add to hierarchical structure
+    if (currentRound.value) {
+      // If there's an active todo, add to that todo's activities
+      const activeTodoItem = currentTodos.value.find(t => t.status === 'in_progress')
+      if (activeTodoItem) {
+        activeTodoItem.activities.push(activity)
+      } else {
+        // Add to round's general activities
+        currentRound.value.activities.push(activity)
+      }
+    }
+  }
+
+  function clearActivity() {
+    currentActivity.value = null
+  }
+
+  function toggleRoundCollapsed(roundId: string) {
+    const round = conversationRounds.value.find(r => r.id === roundId)
+    if (round) {
+      round.collapsed = !round.collapsed
+    }
+  }
+
+  function toggleTodoCollapsed(roundId: string, todoIndex: number) {
+    const round = conversationRounds.value.find(r => r.id === roundId)
+    if (round && round.todos[todoIndex]) {
+      round.todos[todoIndex].collapsed = !round.todos[todoIndex].collapsed
+    }
+  }
+
+  function collapseAllRounds() {
+    conversationRounds.value.forEach(r => {
+      r.collapsed = true
+      r.todos.forEach(t => t.collapsed = true)
+    })
+  }
+
+  function expandAllRounds() {
+    conversationRounds.value.forEach(r => {
+      r.collapsed = false
+      r.todos.forEach(t => t.collapsed = false)
+    })
+  }
+
+  /**
+   * Process PTY output to detect Claude session and activity
+   */
+  function processClaudeOutput(data: string) {
+    // Strip ANSI escape codes for pattern matching
+    const clean = data.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
+
+    // Detect session start - Claude's welcome box or prompt
+    if (!isClaudeSession.value) {
+      if (clean.includes('╭─') || clean.includes('Claude Code')) {
+        startSession()
+        return
+      }
+    }
+
+    // If not in a Claude session, nothing more to do
+    if (!isClaudeSession.value) return
+
+    // Detect session end - return to shell prompt or explicit exit
+    if (clean.includes('Goodbye!')) {
+      endSession()
+      return
+    }
+
+    // Shell prompt detection (indicates Claude exited)
+    const shellPromptPatterns = [
+      /\n[^\n]*\$\s*$/,  // bash: $ at end
+      /\n[^\n]*%\s*$/,   // zsh: % at end
+      /→\s+[^\n]*[~\/]\s*$/, // oh-my-zsh
+    ]
+    for (const pattern of shellPromptPatterns) {
+      if (pattern.test(clean) && !clean.includes('Claude')) {
+        if (activityHistory.value.length > 0) {
+          endSession()
+          return
+        }
+      }
+    }
+
+    // Detect new user prompt (the > prompt followed by text)
+    // This indicates a new conversation round
+    const promptMatch = clean.match(/^>\s+(.{1,50})/)
+    if (promptMatch) {
+      const summary = promptMatch[1].trim()
+      startNewRound(summary.length > 40 ? summary.substring(0, 40) + '...' : summary)
+      return
+    }
+
+    // Detect TodoWrite updates - parse the todo list
+    if (clean.includes('TodoWrite') || clean.includes('todo') && clean.includes('status')) {
+      // Try to parse todo items from the output
+      const todoPattern = /\[?(pending|in_progress|completed)\]?\s*(.+)/gi
+      const matches = [...clean.matchAll(todoPattern)]
+      if (matches.length > 0) {
+        const parsedTodos: TodoItem[] = matches.map(m => ({
+          content: m[2].trim().substring(0, 60),
+          status: m[1].toLowerCase().replace('_', '_') as TodoItem['status'],
+          activities: [],
+          collapsed: false
+        }))
+        updateTodos(parsedTodos)
+      }
+    }
+
+    // Detect thinking/processing (spinner characters)
+    const spinnerChars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+    if (spinnerChars.some(c => clean.includes(c)) || clean.includes('Thinking')) {
+      setActivity({ type: 'thinking', timestamp: Date.now() })
+      return
+    }
+
+    // Detect tool calls - patterns must match file paths or specific formats
+    // For Read/Write/Edit: only match paths starting with /, ./, or ~
+    // This prevents matching status lines like "Read 138 lines"
+
+    // Check for Read with a file path (not "Read 138 lines" status)
+    const readMatch = clean.match(/Read\s+(\/[^\n\s]+|\.\/[^\n\s]+|~[^\n\s]+)/)
+    if (readMatch) {
+      const path = readMatch[1].substring(0, 60)
+      setActivity({
+        type: 'tool_start',
+        tool: 'Read',
+        description: `Reading: ${path}`,
+        timestamp: Date.now()
+      })
+      return
+    }
+
+    // Check for Write with a file path
+    const writeMatch = clean.match(/Write\s+(\/[^\n\s]+|\.\/[^\n\s]+|~[^\n\s]+)/)
+    if (writeMatch) {
+      const path = writeMatch[1].substring(0, 60)
+      setActivity({
+        type: 'tool_start',
+        tool: 'Write',
+        description: `Writing: ${path}`,
+        timestamp: Date.now()
+      })
+      return
+    }
+
+    // Check for Edit with a file path
+    const editMatch = clean.match(/Edit\s+(\/[^\n\s]+|\.\/[^\n\s]+|~[^\n\s]+)/)
+    if (editMatch) {
+      const path = editMatch[1].substring(0, 60)
+      setActivity({
+        type: 'tool_start',
+        tool: 'Edit',
+        description: `Editing: ${path}`,
+        timestamp: Date.now()
+      })
+      return
+    }
+
+    // Other tool patterns (less ambiguous)
+    const toolPatterns: Array<{ pattern: RegExp; tool: ClaudeToolType; desc: string }> = [
+      { pattern: /Bash:\s*([^\n]+)/, tool: 'Bash', desc: 'Running' },
+      { pattern: /Glob\s+([^\n]+)/, tool: 'Glob', desc: 'Finding' },
+      { pattern: /Grep\s+([^\n]+)/, tool: 'Grep', desc: 'Searching' },
+      { pattern: /WebFetch\s+(https?:\/\/[^\n\s]+)/, tool: 'WebFetch', desc: 'Fetching' },
+      { pattern: /WebSearch\s+([^\n]+)/, tool: 'WebSearch', desc: 'Searching' },
+      { pattern: /Task\s+([^\n]+)/, tool: 'Task', desc: 'Subtask' },
+    ]
+
+    for (const { pattern, tool, desc } of toolPatterns) {
+      const match = clean.match(pattern)
+      if (match) {
+        const detail = match[1]?.trim().substring(0, 50) || ''
+        setActivity({
+          type: 'tool_start',
+          tool,
+          description: detail ? `${desc}: ${detail}` : desc,
+          timestamp: Date.now()
+        })
+        return
+      }
+    }
+
+    // Detect tool completion (checkmarks)
+    if (clean.includes('✓') || clean.includes('✔')) {
+      if (currentActivity.value?.type === 'tool_start') {
+        setActivity({
+          type: 'tool_complete',
+          tool: currentActivity.value.tool,
+          description: 'Completed',
+          timestamp: Date.now()
+        })
+      }
+    }
+  }
+
+  return {
+    // State
+    isClaudeSession,
+    currentActivity,
+    activityHistory,
+    sessionStartTime,
+    conversationRounds,
+    currentRoundId,
+    currentTodos,
+    // Computed
+    isThinking,
+    currentTool,
+    currentRound,
+    recentActivities,
+    activeTodo,
+    // Actions
+    startSession,
+    endSession,
+    startNewRound,
+    updateTodos,
+    setActivity,
+    clearActivity,
+    toggleRoundCollapsed,
+    toggleTodoCollapsed,
+    collapseAllRounds,
+    expandAllRounds,
+    processClaudeOutput
+  }
+})

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,10 +1,16 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
+export type GuideTrack = 'terminal' | 'claude-code'
+export type InfoPanelTab = 'guides' | 'activity' | 'notes'
+
 export const useUIStore = defineStore('ui', () => {
   // State
   const showInfoPanel = ref(true)
   const currentGuideId = ref<string | null>('welcome') // null = show guides index
+  const currentTrack = ref<GuideTrack>('terminal') // which guide track is active
+  const activeTab = ref<InfoPanelTab>('guides') // top-level tab in InfoPanel
+  const userNotes = ref('') // user's session notes
 
   // Load UI state from localStorage
   function loadUIState() {
@@ -15,6 +21,9 @@ export const useUIStore = defineStore('ui', () => {
         showInfoPanel.value = state.showInfoPanel ?? true
         // Preserve null (guides index) vs undefined (default to welcome)
         currentGuideId.value = 'currentGuideId' in state ? state.currentGuideId : 'welcome'
+        currentTrack.value = state.currentTrack || 'terminal'
+        activeTab.value = state.activeTab || 'guides'
+        userNotes.value = state.userNotes || ''
       } catch (e) {
         // Ignore parse errors
       }
@@ -25,8 +34,19 @@ export const useUIStore = defineStore('ui', () => {
   function saveUIState() {
     localStorage.setItem('askterminal-ui', JSON.stringify({
       showInfoPanel: showInfoPanel.value,
-      currentGuideId: currentGuideId.value
+      currentGuideId: currentGuideId.value,
+      currentTrack: currentTrack.value,
+      activeTab: activeTab.value,
+      userNotes: userNotes.value
     }))
+  }
+
+  // Set which guide track is active (terminal or claude-code)
+  function setTrack(track: GuideTrack) {
+    currentTrack.value = track
+    // Reset to index when switching tracks
+    currentGuideId.value = null
+    saveUIState()
   }
 
   // Toggle info panel visibility
@@ -53,16 +73,34 @@ export const useUIStore = defineStore('ui', () => {
     saveUIState()
   }
 
+  // Set active top-level tab
+  function setActiveTab(tab: InfoPanelTab) {
+    activeTab.value = tab
+    saveUIState()
+  }
+
+  // Update user notes
+  function setUserNotes(notes: string) {
+    userNotes.value = notes
+    saveUIState()
+  }
+
   return {
     // State
     showInfoPanel,
     currentGuideId,
+    currentTrack,
+    activeTab,
+    userNotes,
     // Methods
     loadUIState,
     saveUIState,
     toggleInfoPanel,
     setInfoPanelVisible,
     setCurrentGuide,
-    showGuidesIndex
+    showGuidesIndex,
+    setTrack,
+    setActiveTab,
+    setUserNotes
   }
 })


### PR DESCRIPTION
## Summary
- Add a dedicated Claude Code guide track with 6 comprehensive guides covering getting started, conversations, tools, workflows, permissions, and best practices
- Implement three-tab InfoPanel system (Guides/Activity/Notes) with skill-level gating for Claude Code content
- Add real-time Claude session detection and activity tracking with hierarchical conversation rounds
- Add running mode in DraftPanel showing current Claude activity with tool badges
- Add loading indicator for improved app startup experience

## Test plan
- [ ] Navigate to Guides tab and verify Terminal Basics / Claude Code track switcher works
- [ ] Verify Claude Code guides are locked for Beginner skill level
- [ ] Change to Intermediate/Advanced and verify Claude Code guides unlock
- [ ] Open each of the 6 Claude guides and verify content renders correctly
- [ ] Type `claude` in DraftPanel and verify command explanation appears
- [ ] Run `claude` command and verify session detection triggers running mode
- [ ] Verify Activity tab shows session history when Claude is running
- [ ] Verify Notes tab allows typing and persists on reload
- [ ] Build the app and verify loading spinner appears on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)